### PR TITLE
fixed: README.adoc contains incorrect AWS_SECRET_KEY_ID

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -144,7 +144,7 @@ The resolution of credentials for S3 uses the same resolution mechanism as the o
 The most notable fact is that if no credentials are set explicitly, it will try to resolve them from environment
 properties of a node it runs on. If that node runs in AWS EC2, it will resolve them by help of that instance itself.
 
-S3 connector will expect to find environment properties `AWS_SECRET_KEY_ID` and `AWS_SECRET_KEY`.
+S3 connector will expect to find environment properties `AWS_ACCESS_KEY_ID` and `AWS_SECRET_KEY`.
 It will also accept `AWS_REGION` and `AWS_ENDPOINT` environment properties - however they are not required.
 If `AWS_ENDPOINT` is set, `AWS_REGION` has to be set too.
 

--- a/src/main/java/com/instaclustr/esop/guice/StorageModules.java
+++ b/src/main/java/com/instaclustr/esop/guice/StorageModules.java
@@ -5,6 +5,7 @@ import com.instaclustr.esop.azure.AzureModule;
 import com.instaclustr.esop.gcp.GCPModule;
 import com.instaclustr.esop.local.LocalFileModule;
 import com.instaclustr.esop.s3.aws.S3Module;
+import com.instaclustr.esop.s3.oracle.OracleModule;
 import com.instaclustr.kubernetes.KubernetesApiModule;
 
 public class StorageModules extends AbstractModule {
@@ -16,5 +17,6 @@ public class StorageModules extends AbstractModule {
         install(new AzureModule());
         install(new GCPModule());
         install(new LocalFileModule());
+        install(new OracleModule());
     }
 }


### PR DESCRIPTION
fixed: OracleModule isn't activated and when using oracle:// as a storagelocation a validation error will occur.